### PR TITLE
change_logger.rb:80:in `index': invalid byte sequence in UTF-8 (ArgumentError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 
 #### [Current]
- * [632117c](../../commit/632117c) - __(Murat Kemal BAYGÜN)__ [#20](../../issues/20) Resolve unexpected autorun behaviour caused by initialize
+ * [78178f7](../../commit/78178f7) - __(Ruben Espinosa)__ Merge pull request [#1](../../issues/1) from kebab-project/develop
 
-#### 1.2.1
+Project update
+ * [5d90550](../../commit/5d90550) - __(Murat Kemal BAYGÜN)__ Release 1.3.0
+ * [632117c](../../commit/632117c) - __(Murat Kemal BAYGÜN)__ [#20](../../issues/20) Resolve unexpected autorun behaviour caused by initialize
  * [05b92d4](../../commit/05b92d4) - __(Murat Kemal BAYGÜN)__ Release 1.2.1
  * [6391f34](../../commit/6391f34) - __(Murat Kemal BAYGÜN)__  [#21](../../issues/21) Add multiline commit support
 
@@ -10,8 +12,6 @@ Multiline commit note support added as referenced in common
 standards, and writing good commit notes. Previous commit was not
 working as expected
 
-
-#### 1.2.0
  * [b509621](../../commit/b509621) - __(Murat Kemal BAYGÜN)__ Release 1.2.0
  * [c9b0d1d](../../commit/c9b0d1d) - __(Murat Kemal BAYGÜN)__ Multiline commit note support added as referenced in common standards, and writing good commit notes
  * [72053a5](../../commit/72053a5) - __(Murat Kemal BAYGÜN)__ [#19](../../issues/19) Check if commit includes issue number before replacing with links

--- a/lib/katip/change_logger.rb
+++ b/lib/katip/change_logger.rb
@@ -74,8 +74,7 @@ module Katip
       output << `git log --pretty=format:" * [%h](#{COMMIT_URL}%h) - __(%an)__ %s%n%n%-b" #{previous_tag} | grep -v "Merge branch "`
 
       output.each do |line|
-
-        line.encode!('utf-8', invalid: :replace, undef: :replace, replace: '')
+        line.encode!('utf-8', 'utf-8', invalid: :replace, undef: :replace, replace: '')
 
         if line.index(/#[1-9][0-9]*/)
           line.gsub!(/#[1-9][0-9]*/) {|s| "[#{s}](#{ISSUE_URL}#{s[-(s.length-1)..-1]})"}


### PR DESCRIPTION
Hi guys 

I had been using your gem, so in the las update (1.3) I found that [the last solution in encoding problem](https://github.com/kebab-project/katip/issues/17) doesn't work in a little couple special cases, so based in this [stack overflow answer](http://stackoverflow.com/posts/8873922/revisions) I had fixed it, please try and tell me it is working in your projects

``` bash
$ katip
/usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:80:in `index': invalid byte sequence in UTF-8 (ArgumentError)
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:80:in `block in parse_change_log'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:76:in `each'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:76:in `parse_change_log'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:18:in `log_changes'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/bin/katip:14:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/katip:23:in `load'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/katip:23:in `<main>'
```

Enforce encoding

``` bash
$ LANG=utf-8 katip
/usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:80:in `index': invalid byte sequence in UTF-8 (ArgumentError)
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:80:in `block in parse_change_log'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:76:in `each'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:76:in `parse_change_log'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/lib/katip/change_logger.rb:18:in `log_changes'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/gems/katip-1.3.0/bin/katip:14:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/katip:23:in `load'
    from /usr/local/rvm/gems/ruby-2.0.0-p247/bin/katip:23:in `<main>'
```
